### PR TITLE
Optimizations

### DIFF
--- a/src/eti2mpa.c
+++ b/src/eti2mpa.c
@@ -9,7 +9,7 @@
 
 void usage(void)
 {
-  fprintf(stderr,"Usage: etiplayer N\n");
+  fprintf(stderr,"Usage: eti2mpa N\n");
   fprintf(stderr,"          N = sub-channel ID to output to stdout\n");
 }
 
@@ -17,7 +17,7 @@ int main(int argc, char* argv[])
 {
   uint8_t buf[6144];  /* Main buffer for an ETI frame */
   int subchanid;
-  int i,n;
+  int i,n,n_frame;
 
   if (argc != 2) {
     usage();
@@ -30,10 +30,16 @@ int main(int argc, char* argv[])
 
   fprintf(stderr,"Decoding channel %d\n",subchanid);
   while (1) {
-    n = read(0,buf,6144);
-    if (n != 6144) {
-      fprintf(stderr,"Read error, exiting\n");
-      return 1;
+    for (n_frame = 0; n_frame < 6144; n_frame += n) {
+      n = read(0,buf + n_frame,6144 - n_frame);
+      if (n == 0) {
+        fprintf(stderr,"End of file, exiting\n");
+        return 0;
+      }
+      if (n < 0) {
+        perror("Read error, exiting");
+        return 1;
+      }
     }
 
     /* TODO: Check Sync etc */

--- a/src/input_sdr.c
+++ b/src/input_sdr.c
@@ -33,9 +33,7 @@ int sdr_demod(struct demapped_transmission_frame_t *tf, struct sdr_state_t *sdr)
   sdr->coarse_freq_shift = 0;
   
   /* write input data into fifo */
-  for (i=0;i<sdr->input_buffer_len;i++) {
-    cbWrite(&(sdr->fifo),&sdr->input_buffer[i]);
-  }
+  cbWriteBytes(&sdr->fifo, sdr->input_buffer, sdr->input_buffer_len);
 
   /* Check for data in fifo */
   if (sdr->fifo.count < 196608*3) {

--- a/src/misc.c
+++ b/src/misc.c
@@ -322,7 +322,7 @@ void dump_ens_info(struct ens_info_t* info)
   for (i=0;i<64;i++) {
     struct subchannel_info_t *sc = &info->subchans[i];
     if (sc->id >= 0) {
-      fprintf(stderr,"SubChId=%d, slForm=%d, StartAddress=%d, size=%d, bitrate=%d, ASCTy=0x%02x\n",sc->id,sc->slForm,sc->start_cu,sc->size,sc->bitrate,sc->ASCTy);
+      fprintf(stderr,"SubChId=%2d, slForm=%d, StartAddress=%3d, size=%3d, bitrate=%3d, ASCTy=0x%02x\n",sc->id,sc->slForm,sc->start_cu,sc->size,sc->bitrate,sc->ASCTy);
     }
   }
 }

--- a/src/sdr_fifo.c
+++ b/src/sdr_fifo.c
@@ -33,29 +33,75 @@ void cbWrite(CircularBuffer *cb, uint8_t *elem) {
     else
         ++ cb->count;
 }
- 
+
+void cbWriteBytes(CircularBuffer *cb, uint8_t *elems, size_t len) {
+	size_t space = cb->size - cb->count;
+	int overflow = 0;
+
+	// handle possible overflows
+	if(len > cb->size) {
+		overflow = 1;
+		size_t ignore = len - cb->size;
+
+		elems += ignore;
+		len -= ignore;
+	}
+	if(len > space) {
+		overflow = 1;
+		size_t remove = len - space;
+
+		cb->start = (cb->start + remove) % cb->size;
+		cb->count -= remove;
+	}
+	if(overflow)
+		fprintf(stderr,"fifo overflow!\n");
+
+	uint32_t index_end = (cb->start + cb->count) % cb->size;
+
+	// split task on index rollover
+	if(len <= cb->size - index_end) {
+		memcpy(cb->elems + index_end, elems, len);
+	} else {
+		size_t first_bytes = cb->size - index_end;
+		memcpy(cb->elems + index_end, elems, first_bytes);
+		memcpy(cb->elems, elems + first_bytes, len - first_bytes);
+	}
+
+	cb->count += len;
+}
+
 void cbRead(CircularBuffer *cb, uint8_t *elem) {
     *elem = cb->elems[cb->start];
     cb->start = (cb->start + 1) % cb->size;
     -- cb->count;
 }
 
+void cbReadBytes(CircularBuffer *cb, uint8_t *elems, size_t len) {
+	size_t real_bytes = cb->count < len ? cb->count : len;
+
+	// split task on index rollover
+	if(real_bytes <= cb->size - cb->start) {
+		memcpy(elems, cb->elems + cb->start, real_bytes);
+	} else {
+		size_t first_bytes = cb->size - cb->start;
+		memcpy(elems, cb->elems + cb->start, first_bytes);
+		memcpy(elems + first_bytes, cb->elems, real_bytes - first_bytes);
+	}
+
+	cb->start = (cb->start + real_bytes) % cb->size;
+	cb->count -= real_bytes;
+}
+
 int32_t sdr_read_fifo(CircularBuffer * fifo,uint32_t bytes,int32_t shift,uint8_t * buffer)
 {
-  int32_t i=0;
-  uint32_t j=0;
   if (shift>0)
     {
-      for (i=0;i<shift;i++)
-	if(!cbIsEmpty(fifo))
-	  cbRead(fifo,&buffer[i]);
-      for (j=0;j<bytes;j++)
-	if(!cbIsEmpty(fifo))
-	  cbRead(fifo,&buffer[j]);
+	  cbReadBytes(fifo, buffer, shift);
+	  cbReadBytes(fifo, buffer, bytes);
     }
   else {
-    for (j=0;j<bytes+shift;j++)
-      cbRead(fifo,&buffer[j]);
+	  if(bytes + shift > 0)
+		  cbReadBytes(fifo, buffer, bytes + shift);
   }
   return 1;
 }

--- a/src/sdr_fifo.h
+++ b/src/sdr_fifo.h
@@ -22,6 +22,7 @@ david.may.muc@googlemail.com
 #include <stdio.h>
 #include <stdint.h>
 #include <malloc.h>
+#include <string.h>
 
 
 typedef struct 
@@ -38,6 +39,8 @@ void cbFree(CircularBuffer *cb);
 int cbIsFull(CircularBuffer *cb);
 int cbIsEmpty(CircularBuffer *cb);
 void cbWrite(CircularBuffer *cb, uint8_t *elem);
+void cbWriteBytes(CircularBuffer *cb, uint8_t *elems, size_t len);
 void cbRead(CircularBuffer *cb, uint8_t *elem);
+void cbReadBytes(CircularBuffer *cb, uint8_t *elems, size_t len);
 
 int32_t sdr_read_fifo(CircularBuffer * fifo,uint32_t bytes,int32_t shift,uint8_t * buffer);


### PR DESCRIPTION
(just copied from my PR to linuxstb/dabtools)

Fixes a read error when non-live sources are used (e.g. cat), as read() then does not return 6144 bytes at once but smaller portions. Furthermore distinguish between read error and EOF.

I just changed the circular buffer in order to read/write multiple bytes instead of a single byte which leads to a significant improvement for me.